### PR TITLE
1.21.1 async youer fully compatible with base mod now.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,7 @@ mod_name=smart-item-deleter-V2
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=MIT
 # The mod version. See https://semver.org/
-mod_version=0.2.3
+mod_version=0.2.3-asyncyouer
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,7 @@ mod_name=smart-item-deleter-V2
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=MIT
 # The mod version. See https://semver.org/
-mod_version=0.2.4-asyncyouer
+mod_version=0.3.1-asyncyouer
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ minecraft_version=1.21.1
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[1.21.1]
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=21.1.208
+neo_version=21.1.215
 # The loader version range can only use the major version of FML as bounds
 loader_version_range=[1,)
 
@@ -32,7 +32,7 @@ mod_name=smart-item-deleter-V2
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=MIT
 # The mod version. See https://semver.org/
-mod_version=0.2.3-asyncyouer
+mod_version=0.2.4-asyncyouer
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/com/metl_group/smart_item_deleter_v2/ModMain.java
+++ b/src/main/java/com/metl_group/smart_item_deleter_v2/ModMain.java
@@ -16,22 +16,20 @@ import com.metl_group.smart_item_deleter_v2.config.CleanupConfig;
 public final class ModMain {
     public static final String MOD_ID = "smart_item_deleter_v2";
 
-    // WICHTIG: ModContainer im Konstruktor annehmen und dort Config registrieren
     public ModMain(ModContainer container) {
         container.registerConfig(ModConfig.Type.SERVER, CleanupConfig.SERVER_SPEC);
     }
 
-    // HINWEIS: bus-Parameter weggelassen (Auto-Erkennung)
     @EventBusSubscriber(modid = MOD_ID)
     public static final class ModBus {
         @SubscribeEvent
         public static void onCommonSetup(final FMLCommonSetupEvent e) {
-            // Hooks bei Bedarf
         }
 
         @SubscribeEvent
         public static void onConfigReload(final ModConfigEvent.Reloading e) {
             if (e.getConfig().getSpec() == CleanupConfig.SERVER_SPEC) {
+                CleanupConfig.trackConfig(e.getConfig());
                 CleanupConfig.bake();
             }
         }
@@ -39,12 +37,12 @@ public final class ModMain {
         @SubscribeEvent
         public static void onConfigLoad(final ModConfigEvent.Loading e) {
             if (e.getConfig().getSpec() == CleanupConfig.SERVER_SPEC) {
+                CleanupConfig.trackConfig(e.getConfig());
                 CleanupConfig.bake();
             }
         }
     }
 
-    // RegisterCommandsEvent liegt auf der Game/Event-Bus-Seite – Auto-Erkennung reicht
     @EventBusSubscriber(modid = MOD_ID)
     public static final class GameBus {
         @SubscribeEvent

--- a/src/main/java/com/metl_group/smart_item_deleter_v2/command/CleanupCommands.java
+++ b/src/main/java/com/metl_group/smart_item_deleter_v2/command/CleanupCommands.java
@@ -1,17 +1,28 @@
 package com.metl_group.smart_item_deleter_v2.command;
 
+import com.metl_group.smart_item_deleter_v2.config.CleanupConfig;
 import com.metl_group.smart_item_deleter_v2.core.ItemCleanupSystem;
 import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.suggestion.SuggestionsBuilder;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
+import net.neoforged.neoforge.common.ModConfigSpec;
 
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 
 import static com.metl_group.smart_item_deleter_v2.core.ItemCleanupSystem.RunSummary;
 
@@ -32,6 +43,19 @@ public final class CleanupCommands {
                 )
                 .then(Commands.literal("dryrun")
                         .executes(CleanupCommands::executeDryRun)
+                )
+                .then(Commands.literal("config")
+                        .then(Commands.literal("list")
+                                .executes(CleanupCommands::executeConfigList)
+                        )
+                        .then(Commands.argument("key", StringArgumentType.word())
+                                .suggests(CleanupCommands::suggestConfigKeys)
+                                .executes(CleanupCommands::executeConfigGet)
+                                .then(Commands.argument("value", StringArgumentType.greedyString())
+                                        .suggests(CleanupCommands::suggestConfigValue)
+                                        .executes(CleanupCommands::executeConfigSet)
+                                )
+                        )
                 )
         );
     }
@@ -164,6 +188,138 @@ public final class CleanupCommands {
         }
 
         return 1;
+    }
+
+    private static int executeConfigList(CommandContext<CommandSourceStack> ctx) {
+        var source = ctx.getSource();
+        Map<String, CleanupConfig.ConfigBinding> bindings = new LinkedHashMap<>(CleanupConfig.discoverBindings());
+
+        if (bindings.isEmpty()) {
+            source.sendFailure(Component.literal("No dynamic config entries were discovered."));
+            return 0;
+        }
+
+        source.sendSuccess(() -> Component.literal("Cleanup config options (current values):"), false);
+        bindings.forEach((path, binding) -> source.sendSuccess(
+                () -> Component.literal(String.format(Locale.ROOT, "- %s = %s", path, renderValue(binding.value().get()))),
+                false));
+        return bindings.size();
+    }
+
+    private static int executeConfigGet(CommandContext<CommandSourceStack> ctx) throws CommandSyntaxException {
+        var source = ctx.getSource();
+        String key = StringArgumentType.getString(ctx, "key");
+        CleanupConfig.ConfigBinding binding = locateBinding(key);
+
+        source.sendSuccess(() -> Component.literal(String.format(Locale.ROOT, "%s = %s", key, renderValue(binding.value().get()))), false);
+        return 1;
+    }
+
+    private static int executeConfigSet(CommandContext<CommandSourceStack> ctx) throws CommandSyntaxException {
+        var source = ctx.getSource();
+        String key = StringArgumentType.getString(ctx, "key");
+        String rawValue = StringArgumentType.getString(ctx, "value");
+
+        CleanupConfig.ConfigBinding binding = locateBinding(key);
+        Object parsed = parseValue(rawValue, binding);
+
+        if (!binding.spec().test(parsed)) {
+            throw CommandSyntaxException.BUILT_IN_EXCEPTIONS.dispatcherParseException()
+                    .create(String.format(Locale.ROOT, "Value '%s' rejected by config constraints for %s", rawValue, key));
+        }
+
+        Object old = binding.value().get();
+        setBindingValue(binding, parsed);
+        binding.value().save();
+
+        CleanupConfig.bake();
+
+        source.sendSuccess(() -> Component.literal(String.format(Locale.ROOT,
+                "Updated %s: %s -> %s", key, renderValue(old), renderValue(binding.value().get()))), true);
+        return 1;
+    }
+
+    private static Object parseValue(String rawValue, CleanupConfig.ConfigBinding binding) throws CommandSyntaxException {
+        Object current = binding.value().get();
+        try {
+            if (current instanceof Boolean) {
+                if (rawValue.equalsIgnoreCase("true") || rawValue.equalsIgnoreCase("false")) {
+                    return Boolean.parseBoolean(rawValue);
+                }
+                throw new IllegalArgumentException("expected boolean");
+            }
+            if (current instanceof Integer) {
+                return Integer.parseInt(rawValue);
+            }
+            if (current instanceof Long) {
+                return Long.parseLong(rawValue);
+            }
+            if (current instanceof Double) {
+                return Double.parseDouble(rawValue);
+            }
+            if (current instanceof Enum<?> e) {
+                return Enum.valueOf(e.getDeclaringClass(), rawValue.toUpperCase(Locale.ROOT));
+            }
+            if (current instanceof List<?> ignored) {
+                return Arrays.stream(rawValue.split(","))
+                        .map(String::trim)
+                        .filter(s -> !s.isBlank())
+                        .toList();
+            }
+        } catch (IllegalArgumentException ex) {
+            throw CommandSyntaxException.BUILT_IN_EXCEPTIONS.dispatcherParseException()
+                    .create(String.format(Locale.ROOT, "Could not parse value '%s' for %s", rawValue, String.join(".", binding.value().getPath())));
+        }
+
+        return rawValue;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void setBindingValue(CleanupConfig.ConfigBinding binding, Object parsed) {
+        ((ModConfigSpec.ConfigValue<Object>) binding.value()).set(parsed);
+    }
+
+    private static CompletableFuture<Suggestions> suggestConfigKeys(CommandContext<CommandSourceStack> ctx, SuggestionsBuilder builder) {
+        CleanupConfig.discoverBindings().keySet().forEach(builder::suggest);
+        return builder.buildFuture();
+    }
+
+    private static CompletableFuture<Suggestions> suggestConfigValue(CommandContext<CommandSourceStack> ctx, SuggestionsBuilder builder) {
+        String key = StringArgumentType.getString(ctx, "key");
+        CleanupConfig.ConfigBinding binding = CleanupConfig.discoverBindings().get(key);
+        if (binding == null) {
+            return builder.buildFuture();
+        }
+
+        Object current = binding.value().get();
+        if (current instanceof Boolean) {
+            builder.suggest("true");
+            builder.suggest("false");
+        } else if (current instanceof Enum<?> e) {
+            for (Enum<?> constant : e.getDeclaringClass().getEnumConstants()) {
+                builder.suggest(constant.name().toLowerCase(Locale.ROOT));
+            }
+        } else if (current instanceof List<?> list && !list.isEmpty()) {
+            builder.suggest(renderValue(list));
+        } else {
+            builder.suggest(current.toString());
+        }
+        return builder.buildFuture();
+    }
+
+    private static CleanupConfig.ConfigBinding locateBinding(String key) throws CommandSyntaxException {
+        CleanupConfig.ConfigBinding binding = CleanupConfig.discoverBindings().get(key);
+        if (binding == null) {
+            throw CommandSyntaxException.BUILT_IN_EXCEPTIONS.dispatcherUnknownArgument().create();
+        }
+        return binding;
+    }
+
+    private static String renderValue(Object value) {
+        if (value instanceof List<?> list) {
+            return list.stream().map(Objects::toString).reduce((a, b) -> a + "," + b).orElse("");
+        }
+        return String.valueOf(value);
     }
 
     private record ItemEntityPreview(String name, int count, double x, double y, double z, long ageMs) {

--- a/src/main/java/com/metl_group/smart_item_deleter_v2/config/CleanupConfig.java
+++ b/src/main/java/com/metl_group/smart_item_deleter_v2/config/CleanupConfig.java
@@ -1,6 +1,12 @@
 package com.metl_group.smart_item_deleter_v2.config;
 
 import net.neoforged.neoforge.common.ModConfigSpec;
+import net.neoforged.fml.config.ModConfig;
+
+import java.lang.reflect.Field;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 public final class CleanupConfig {
     public enum FilterMode { BLACKLIST, WHITELIST }
@@ -18,6 +24,7 @@ public final class CleanupConfig {
     public static boolean jitterEnabled;
     public static int scanJitterTicks; // e.g. 2
     public static boolean consoleDebugLogging;
+    public static ModConfig serverConfig;
     private static final ModConfigSpec.BooleanValue CFG_JITTER_ENABLED;
     private static final ModConfigSpec.IntValue CFG_SCAN_JITTER;
     private static final ModConfigSpec.BooleanValue CFG_CONSOLE_DEBUG_LOGGING;
@@ -73,7 +80,6 @@ public final class CleanupConfig {
         protectNamedItems    = CFG_PROTECT_NAMED.get();
         consoleDebugLogging  = CFG_CONSOLE_DEBUG_LOGGING.get();
         filterMode           = CFG_FILTER_MODE.get();
-        //filterList         = java.util.List.copyOf(CFG_FILTER_LIST.get());
         filterList           = CFG_FILTER_LIST.get().stream().map(Object::toString).toList();
         if (filterList.isEmpty()) {
             filterList = java.util.List.of();
@@ -81,4 +87,38 @@ public final class CleanupConfig {
     }
 
     private CleanupConfig() {}
+
+    public static Map<String, ConfigBinding> discoverBindings() {
+        Map<String, ConfigBinding> bindings = new LinkedHashMap<>();
+
+        for (Field field : CleanupConfig.class.getDeclaredFields()) {
+            if (!ModConfigSpec.ConfigValue.class.isAssignableFrom(field.getType())) {
+                continue;
+            }
+            try {
+                field.setAccessible(true);
+                ModConfigSpec.ConfigValue<?> value = (ModConfigSpec.ConfigValue<?>) field.get(null);
+                if (value == null) {
+                    continue;
+                }
+                List<String> path = value.getPath();
+                ModConfigSpec.ValueSpec spec = value.getSpec();
+                bindings.put(String.join(".", path), new ConfigBinding(value, spec));
+            } catch (IllegalAccessException ignored) {
+                // Skip inaccessible entries
+            }
+        }
+
+        return bindings.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .collect(LinkedHashMap::new, (m, e) -> m.put(e.getKey(), e.getValue()), Map::putAll);
+    }
+
+    public static void trackConfig(ModConfig config) {
+        if (config.getSpec() == SERVER_SPEC) {
+            serverConfig = config;
+        }
+    }
+
+    public record ConfigBinding(ModConfigSpec.ConfigValue<?> value, ModConfigSpec.ValueSpec spec) {}
 }

--- a/src/main/java/com/metl_group/smart_item_deleter_v2/config/CleanupConfig.java
+++ b/src/main/java/com/metl_group/smart_item_deleter_v2/config/CleanupConfig.java
@@ -46,7 +46,7 @@ public final class CleanupConfig {
 
         B.push("logging");
         CFG_CONSOLE_DEBUG_LOGGING = B.comment("When false, the mod will not print cleanup summaries to the server console.")
-                .define("consoleDebugLogging", true);
+                .define("consoleDebugLogging", false);
         B.pop();
 
         B.push("filter");
@@ -64,17 +64,17 @@ public final class CleanupConfig {
     }
 
     public static void bake() {
-        scanIntervalTicks   = CFG_SCAN_INTERVAL.get();
-        scanJitterTicks = CFG_SCAN_JITTER.get();
-        jitterEnabled   = CFG_JITTER_ENABLED.get();
-        entityCountThreshold= CFG_THRESHOLD.get();
+        scanIntervalTicks    = CFG_SCAN_INTERVAL.get();
+        scanJitterTicks      = CFG_SCAN_JITTER.get();
+        jitterEnabled        = CFG_JITTER_ENABLED.get();
+        entityCountThreshold = CFG_THRESHOLD.get();
         deletePercentage     = CFG_DELETE_PERCENT.get();
-        minItemAgeMs        = CFG_MIN_AGE_MS.get();
-        protectNamedItems   = CFG_PROTECT_NAMED.get();
-        consoleDebugLogging = CFG_CONSOLE_DEBUG_LOGGING.get();
-        filterMode          = CFG_FILTER_MODE.get();
-        //filterList          = java.util.List.copyOf(CFG_FILTER_LIST.get());
-        filterList          = CFG_FILTER_LIST.get().stream().map(Object::toString).toList();
+        minItemAgeMs         = CFG_MIN_AGE_MS.get();
+        protectNamedItems    = CFG_PROTECT_NAMED.get();
+        consoleDebugLogging  = CFG_CONSOLE_DEBUG_LOGGING.get();
+        filterMode           = CFG_FILTER_MODE.get();
+        //filterList         = java.util.List.copyOf(CFG_FILTER_LIST.get());
+        filterList           = CFG_FILTER_LIST.get().stream().map(Object::toString).toList();
         if (filterList.isEmpty()) {
             filterList = java.util.List.of();
         }

--- a/src/main/java/com/metl_group/smart_item_deleter_v2/core/ItemCleanupSystem.java
+++ b/src/main/java/com/metl_group/smart_item_deleter_v2/core/ItemCleanupSystem.java
@@ -12,7 +12,6 @@ import net.neoforged.neoforge.event.tick.ServerTickEvent;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.item.ItemEntity;
-import net.minecraft.world.phys.AABB;
 
 import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
@@ -270,15 +269,20 @@ public final class ItemCleanupSystem {
         }
     }
 
-    // Collect all item entities in the level. Bounding box is expanded beyond world border to be safe.
+    /**
+     * Collect all loaded item entities.
+     *
+     * <p>Using {@link ServerLevel#getAllEntities()} avoids accessing protected chunk internals while still
+     * respecting the server's view of loaded entities (no chunk loading or world-spanning searches).
+     */
     private static List<ItemEntity> allItems(ServerLevel level) {
-        AABB bb = new AABB(
-                level.getWorldBorder().getMinX() - 1_000, level.getMinBuildHeight(),
-                level.getWorldBorder().getMinZ() - 1_000,
-                level.getWorldBorder().getMaxX() + 1_000, level.getMaxBuildHeight(),
-                level.getWorldBorder().getMaxZ() + 1_000
-        );
-        return level.getEntitiesOfClass(ItemEntity.class, bb);
+        List<ItemEntity> items = new ArrayList<>();
+        for (var entity : level.getAllEntities()) {
+            if (entity instanceof ItemEntity ie) {
+                items.add(ie);
+            }
+        }
+        return items;
     }
 
     private static final class ModLogger {


### PR DESCRIPTION
**Changelog**  
Replaced the single server-tick listener with a per-level LevelTickEvent handler that keeps its own next-run schedule per dimension, runs the cleanup on the correct world thread, and drops stale schedules when a level unloads—preventing AsyncYouer from stalling while worlds tick concurrently.
And removed AABB scanning in favor of just using the global items list.  

default for ```consoleDebugLogging``` is now false  

Made config changeable through chat commands. -> Instantly applying them.

Extended the /cleanup command with a dynamic config branch that lists, reads, validates, and sets options with suggestions, saves to disk, and re-bakes the configuration after successful writes.

Added dynamic discovery of config bindings, tracking of the active server config, and helpers to surface ModConfigSpec-driven constraints for runtime updates.
Updated config load/reload events to capture the active server config before baking values for use by commands and systems.